### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/hostsvc-position-build-publish.yaml
+++ b/.github/workflows/hostsvc-position-build-publish.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       packages: write
 
-    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/service-build.yml@0.11.0-nightly
+    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/service-build.yml@f20a6a5bd7b78a23f94412532a5e2f7d0c89d13b # 0.11.0-nightly
     with:
       APP_PROJECT: ./src/hostsvc-position.csproj
       NUGET_PROJECT: ./src_pluginBase/pluginBase.csproj
@@ -34,7 +34,7 @@ jobs:
       contents: read
       packages: write
 
-    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/service-build.yml@0.11.0-nightly
+    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/service-build.yml@f20a6a5bd7b78a23f94412532a5e2f7d0c89d13b # 0.11.0-nightly
     with:
       APP_PROJECT: ./src/hostsvc-position.csproj
       NUGET_PROJECT: ./src_pluginBase/pluginBase.csproj

--- a/.github/workflows/hotsvc-position-test.yaml
+++ b/.github/workflows/hotsvc-position-test.yaml
@@ -14,7 +14,7 @@ jobs:
       checks: write
       pull-requests: write
 
-    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/test-app.yaml@0.11.0-nightly
+    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/test-app.yaml@f20a6a5bd7b78a23f94412532a5e2f7d0c89d13b # 0.11.0-nightly
     with:
       APP_NAME: hostsvc-position
       WORKFLOW_AGENT: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
       checks: write
       pull-requests: write
 
-    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/test-app.yaml@0.11.0-nightly
+    uses: microsoft/azure-orbital-space-sdk-github-actions/.github/workflows/test-app.yaml@f20a6a5bd7b78a23f94412532a5e2f7d0c89d13b # 0.11.0-nightly
     with:
       APP_NAME: hostsvc-position
       WORKFLOW_AGENT: spacesdk-ubuntu-2204LTS-arm64


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
